### PR TITLE
fix missing StringArray.h by pinning ESPAsyncWebServer

### DIFF
--- a/yoRadio/platformio.ini
+++ b/yoRadio/platformio.ini
@@ -26,7 +26,7 @@ lib_deps =
   adafruit/Adafruit BusIO@^1.14.5
   adafruit/Adafruit GFX Library@^1.11.9
   bblanchon/ArduinoJson@^7.0.4
-  https://github.com/me-no-dev/ESPAsyncWebServer
+  https://github.com/me-no-dev/ESPAsyncWebServer#b70d36f
 
 platform_packages =
 	platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.4


### PR DESCRIPTION
ESPAsyncWebServer dropped support for StringArray.h some time ago. Use a fixed version where ESPAsyncWebServer still has support for it.